### PR TITLE
Add blocks around case bodys

### DIFF
--- a/postcard-bindgen-core/src/code_gen/js/generateable/container/enums.rs
+++ b/postcard-bindgen-core/src/code_gen/js/generateable/container/enums.rs
@@ -91,10 +91,10 @@ pub mod ser {
 
         Case::new(
             variant_name,
-            quote! {
+            quote! {{
                 s.serialize_number(U32_BYTES, false, $index);
                 $body
-            },
+            }},
         )
     }
 }


### PR DESCRIPTION
This is a simple solution to fix #78. It basically just creates a JavaScript block within `case` statements that encapsulates the generated variables.